### PR TITLE
fix neighbourhood calculation

### DIFF
--- a/gui.c
+++ b/gui.c
@@ -142,28 +142,25 @@ static gboolean daMap_draw(GtkWidget *widget, cairo_t *cr, struct gui *g)
 
 	painting = true;
 
-	/* available space */
-	gint w, h;
-	GtkAllocation alloc;
-
-	gtk_widget_get_allocation(g->daMapContainer, &alloc);
-	w = alloc.width;
-	h = alloc.height;
-	/* resize map */
-	gint newrows, newcols;
-
-	newrows = h / g->draw_scale;
-	newcols = w / g->draw_scale;
 	if (g->resetting_size) {
 		g->resetting_size = false;
-		/* gtk_widget_set_size_request(g->daMapContainer, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale); */
-		/* gtk_widget_set_size_request(widget, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale); */
 		gtk_window_resize(GTK_WINDOW(g->awMain), 30, 30);
 	} else {
+		GtkAllocation alloc;
+		gint w, h;
+
+		gtk_widget_get_allocation(g->daMapContainer, &alloc);
+		w = alloc.width;
+		h = alloc.height;
+		gint newrows, newcols;
+
+		newrows = h / g->draw_scale;
+		newcols = w / g->draw_scale;
 		if (newrows != g->gc->rows || newcols != g->gc->cols)
 			reset_world(g, newrows, newcols);
-		gtk_widget_set_size_request(widget, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale);
 	}
+	gtk_widget_set_size_request(widget, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale);
+
 
 	/* Clear screen */
 	cairo_set_source_rgb(cr, 0, 0, 0);
@@ -183,7 +180,7 @@ static gboolean daMap_draw(GtkWidget *widget, cairo_t *cr, struct gui *g)
 
 	painting = false;
 
-	return false;
+	return FALSE;
 }
 
 static gboolean timer_cb(gpointer gui)
@@ -233,8 +230,8 @@ static gboolean daMap_button_press_event(GtkWidget *widget, GdkEventButton *e,
 	int j = true_y / g->draw_scale;
 */
 
-	int i = e->y / g->draw_scale;
-	int j = e->x / g->draw_scale;
+	int i = (int) (e->y / g->draw_scale);
+	int j = (int) (e->x / g->draw_scale);
 
 	if (e->button == 1) {
 		g->world->set_cell(g->world, i, j, ALIVE);
@@ -265,8 +262,7 @@ static gboolean daMap_motion_notify_event(GtkWidget *widget, GdkEventMotion *eve
 	int i = (int) event->y / g->draw_scale;
 	int j = (int) event->x / g->draw_scale;
 
-	if (event->state & GDK_BUTTON1_MASK)
-	{
+	if (event->state & GDK_BUTTON1_MASK) {
 		g->world->set_cell(g->world, i, j, ALIVE);
 		g->something_changed = true;
 		gtk_widget_queue_draw(widget);
@@ -287,6 +283,7 @@ static void tglToroidal_toggled(GtkWidget *widget, struct gui *g)
 
 	reset_world(g, g->gc->rows, g->gc->cols);
 	gtk_widget_set_size_request(GTK_WIDGET(g->daMap), g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale);
+	gtk_widget_queue_draw(GTK_WIDGET(g->daMap));
 }
 
 static void sclSpeed_value_changed(GtkWidget *widget, struct gui *g)

--- a/gui.c
+++ b/gui.c
@@ -144,6 +144,7 @@ static gboolean daMap_draw(GtkWidget *widget, cairo_t *cr, struct gui *g)
 
 	if (g->resetting_size) {
 		g->resetting_size = false;
+		gtk_widget_set_size_request(widget, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale);
 		gtk_window_resize(GTK_WINDOW(g->awMain), 30, 30);
 	} else {
 		GtkAllocation alloc;
@@ -158,8 +159,8 @@ static gboolean daMap_draw(GtkWidget *widget, cairo_t *cr, struct gui *g)
 		newcols = w / g->draw_scale;
 		if (newrows != g->gc->rows || newcols != g->gc->cols)
 			reset_world(g, newrows, newcols);
+		gtk_widget_set_size_request(widget, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale);
 	}
-	gtk_widget_set_size_request(widget, g->gc->cols * g->draw_scale, g->gc->rows * g->draw_scale);
 
 
 	/* Clear screen */

--- a/world.c
+++ b/world.c
@@ -195,7 +195,6 @@ static unsigned char _next_state_of(const struct world *this, int i, int j)
 					this->get_cell_previous(this, _N_(i, j)) +
 					this->get_cell_previous(this, _NE(i, j)) +
 					this->get_cell_previous(this, _W_(i, j)) +
-					this->get_cell_previous(this, _O_(i, j)) +
 					this->get_cell_previous(this, _E_(i, j)) +
 					this->get_cell_previous(this, _SW(i, j)) +
 					this->get_cell_previous(this, _S_(i, j)) +

--- a/world.c
+++ b/world.c
@@ -135,8 +135,8 @@ static void _world_init_empty(struct world *this)
 {
 	assert(ATTR_IS_SET(this->world_pr->flags, WORLD_MATRICES_ALLOCATED));
 
-	memset(this->world_pr->previous_matrix, DEAD, this->world_pr->rows * this->world_pr->cols);
-	memset(this->world_pr->current_matrix, DEAD, this->world_pr->rows * this->world_pr->cols);
+	memset(this->world_pr->previous_matrix, DEAD, (size_t) (this->world_pr->rows * this->world_pr->cols));
+	memset(this->world_pr->current_matrix, DEAD, (size_t) (this->world_pr->rows * this->world_pr->cols));
 
 	struct list_element *it, *_t;
 
@@ -219,7 +219,7 @@ static void _world_next_gen(struct world *this)
 
 	this->world_pr->previous_matrix = this->world_pr->current_matrix;
 	this->world_pr->current_matrix = _tp;
-	memset(this->world_pr->current_matrix, DEAD, this->world_pr->rows * this->world_pr->cols);
+	memset(this->world_pr->current_matrix, DEAD, (size_t) (this->world_pr->rows * this->world_pr->cols));
 
 	struct list_element *it, *_t;
 	struct list_head to_be_checked;
@@ -402,6 +402,14 @@ static unsigned char *_world_get_previous_matrix(const struct world *this)
 
 static void _world_refresh_alive_cells_index(struct world *this)
 {
+
+	struct list_element *it, *_t;
+
+	list_for_each_entry_safe(it, _t, &this->world_pr->alive_list, list) {
+		list_del(&it->list);
+		free(it);
+	}
+
 	INIT_LIST_HEAD(&this->world_pr->alive_list);
 	this->world_pr->alive_cells_count = 0;
 	for (int i = 0; i < this->world_pr->rows; i++) {


### PR DESCRIPTION
@profedotc introduje este fallo al refactorizar código y pasarlo a "objetos", se soluciona con una línea, como los buenos parches. Al contar el número de vecinos, se incluía al propio, por eso no salía correcto el glider, ahora ya sí.